### PR TITLE
Windows Compatibility Error

### DIFF
--- a/retico/__init__.py
+++ b/retico/__init__.py
@@ -1,6 +1,6 @@
 import retico.ius as ius
 import retico.modules as modules
-import retico.aux as aux
+import retico._aux as aux
 
 from retico_core.network import *
 

--- a/retico/_aux.py
+++ b/retico/_aux.py
@@ -1,0 +1,3 @@
+from retico_googletts import GoogleTTS
+
+from retico_wav2vecasr import Wav2Vec2ASR

--- a/retico/aux.py
+++ b/retico/aux.py
@@ -1,3 +1,0 @@
-from retico_googletts import GoogleTTS
-
-from retico_wav2vecasr import Wav2Vec2ASR


### PR DESCRIPTION
No files with aux not allowed on a windows system. thus aux.py had an error.

https://superuser.com/questions/206423/windows-7-can-not-rename-a-file-to-aux-svg-the-specified-device-name-is-inva